### PR TITLE
data storage: replace OneDrive with Google Drive

### DIFF
--- a/R/report_methodology/report methodology and results.Rmd
+++ b/R/report_methodology/report methodology and results.Rmd
@@ -56,28 +56,17 @@ lapply(
 ) %>%
   invisible()
 
+# Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data_copy/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
   data_storage_path <- data_storage_path[2]
@@ -86,7 +75,7 @@ if (length(data_storage_path) > 1) {
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets1"
+    "_targets_h1"
   )
 
 # set configuration for _target storage

--- a/R/report_methodology/report_methodology.Rmd
+++ b/R/report_methodology/report_methodology.Rmd
@@ -70,37 +70,26 @@ lapply(
 ) %>%
   invisible()
 
+# Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
-  data_storage_path <- data_storage_path[1]
+  data_storage_path <- data_storage_path[2]
 }
 
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets"
+    "_targets_h1"
   )
 
 # set configuration for _target storage

--- a/R/report_validation/Validation_of_results.Rmd
+++ b/R/report_validation/Validation_of_results.Rmd
@@ -58,28 +58,17 @@ lapply(
 ) %>%
   invisible()
 
+# Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data_copy/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
   data_storage_path <- data_storage_path[2]
@@ -88,7 +77,7 @@ if (length(data_storage_path) > 1) {
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets1"
+    "_targets_h1"
   )
 
 # set configuration for _target storage

--- a/R/summed_visualisation.md
+++ b/R/summed_visualisation.md
@@ -23,36 +23,24 @@ lapply(
 ``` r
 # Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
-  data_storage_path <- data_storage_path[1]
+  data_storage_path <- data_storage_path[2]
 }
 
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets"
+    "_targets_h1"
   )
 
 # set configuration for _target storage

--- a/R/summed_visualisation.qmd
+++ b/R/summed_visualisation.qmd
@@ -27,36 +27,24 @@ lapply(
 
 # Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
-  data_storage_path <- data_storage_path[1]
+  data_storage_path <- data_storage_path[2]
 }
 
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets"
+    "_targets_h1"
   )
 
 # set configuration for _target storage

--- a/_targets.R
+++ b/_targets.R
@@ -6,27 +6,15 @@ library(future.callr)
 
 # Define directory for external storage for users
 auth_tibble <-
-  tibble::tibble(
-    name = c("ondre", "omo084", "vfe032", "vfe032", "sfl046", "kbh022"),
-    paths = c(
-      "C:/Users/ondre/OneDrive - University of Bergen/HOPE_data/",
-      "C:/Users/omo084/OneDrive - University of Bergen/HOPE_data/",
-      "/Users/vfe032/Library/CloudStorage/OneDrive-SharedLibraries-UniversityofBergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/vfe032/OneDrive - University of Bergen/HOPE_data_copy/",
-      "C:/Users/sfl046/University of Bergen/Ondrej Mottl - HOPE_data/",
-      "C:/Users/kbh022/University of Bergen/Ondrej Mottl - HOPE_data/"
-    )
+  tibble::tribble(
+    ~name, ~path,
+    "ondrej", "C:/Users/ondre/My Drive/"
   )
-
-sys_info <- Sys.info()
-
-username <-
-  sys_info["user"]
 
 data_storage_path <-
   auth_tibble %>%
-  dplyr::filter(name == username) %>%
-  purrr::pluck("paths")
+  dplyr::filter(name == Sys.info()["user"]) %>%
+  purrr::pluck("path")
 
 if (length(data_storage_path) > 1) {
   data_storage_path <- data_storage_path[2]
@@ -35,7 +23,7 @@ if (length(data_storage_path) > 1) {
 external_storage_targets <-
   paste0(
     data_storage_path,
-    "HOPE_Hypothesis1/_targets1"
+    "_targets_h1"
   )
 
 # set configuration for _target storage


### PR DESCRIPTION
# Data management
- OneDrive is not accessible across institutions.
- After consideration of {googledrive} and {osfr} it is easiest if everyone just adds the shared Google account to their Google Drive desktop App
- all users have to add their correct path to the `auth_tibble` again
- close #88