### PR TITLE
Checking consistency between data for RC and calculation of SPD

### DIFF
--- a/R/project/04_calculate_spd.R
+++ b/R/project/04_calculate_spd.R
@@ -70,8 +70,6 @@ data_c14_subset <-
 # 2. Calculate spd for each distance per locality -----
 #---------------------------------------------------------------#
 
-library(furrr)
-
 n_cores <-
   as.numeric(
     parallelly::availableCores()


### PR DESCRIPTION
ISSUE
There are 344 records that has not a match between which records has minimum 50 dates within 250 distance and estimates of spd. I am mostly worry about records that has spd estimates when there are no RC dates.

Need to check the iwalk, vector list processing, is it combining the data by dataset_ids correctly?

Answer: No it was randomly assigning dataset_id to resulting spd calculations . 
Issue solved and new data run works fine. 