### PR TITLE
Model predictors - model evaluation: add LOO test to be optional

### DIFF
--- a/R/project/predictor_models/05_Evaluate_models.R
+++ b/R/project/predictor_models/05_Evaluate_models.R
@@ -23,6 +23,9 @@ source(
   )
 )
 
+
+test_for_predictive_power <- FALSE
+
 pareto_k_threshold <- 0.7
 loo_threshold <- 0.1
 rhat_threshold <- 1.1
@@ -221,7 +224,8 @@ purrr::pwalk(
 
     need_to_be_rerun <-
       isFALSE(pass_rhat_test) |
-        (isFALSE(pass_loo_test) & isFALSE(is_event))
+        # (isFALSE(pass_loo_test) & isFALSE(is_event)) |
+        (isFALSE(pass_loo_test) & isTRUE(test_for_predictive_power))
 
     # Update the model table -----
 


### PR DESCRIPTION
# Model evaluation
- test for model predictive power (LOO) is not optional